### PR TITLE
#2 KleisliIO code, tests and benchmarks moved from ZIO project

### DIFF
--- a/benchmarks/src/main/scala/scalaz/kleisliio/ArrayFillBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/kleisliio/ArrayFillBenchmark.scala
@@ -11,6 +11,7 @@ import scala.collection.immutable.Range
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
 class ArrayFillBenchmarks {
+
   @Param(Array("10000"))
   var size: Int = _
 
@@ -23,21 +24,21 @@ class ArrayFillBenchmarks {
     def arrayFill(array: Array[Int]): KleisliIO[Nothing, Int, Int] = {
       val condition = KleisliIO.lift[Int, Boolean]((i: Int) => i < array.length)
 
-      KleisliIO.whileDo[Nothing, Int](condition)(
-        KleisliIO.impureVoid[Int, Int] { i: Int =>
-          array.update(i, i)
+      KleisliIO.whileDo[Nothing, Int](condition)(KleisliIO.impureVoid[Int, Int] { i: Int =>
+        array.update(i, i)
 
-          i + 1
-        })
+        i + 1
+      })
     }
 
     unsafeRun(
       for {
         array <- IO.sync[Array[Int]](createTestArray)
-        _ <- arrayFill(array).run(0)
+        _     <- arrayFill(array).run(0)
       } yield ()
     )
   }
+
   @Benchmark
   def catsArrayFill() = {
     import cats.effect.IO
@@ -48,9 +49,10 @@ class ArrayFillBenchmarks {
 
     (for {
       array <- IO(createTestArray)
-      _ <- arrayFill(array)(0)
+      _     <- arrayFill(array)(0)
     } yield ()).unsafeRunSync()
   }
+
   @Benchmark
   def monixArrayFill() = {
     import monix.eval.Task
@@ -62,7 +64,7 @@ class ArrayFillBenchmarks {
 
     (for {
       array <- Task.eval(createTestArray)
-      _ <- arrayFill(array)(0)
+      _     <- arrayFill(array)(0)
     } yield ()).runSyncUnsafe(Duration.Inf)
   }
 }

--- a/benchmarks/src/main/scala/scalaz/kleisliio/ArrayFillBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/kleisliio/ArrayFillBenchmark.scala
@@ -1,0 +1,68 @@
+package scalaz.zio
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import scala.concurrent.duration.Duration
+import scala.collection.immutable.Range
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class ArrayFillBenchmarks {
+  @Param(Array("10000"))
+  var size: Int = _
+
+  def createTestArray: Array[Int] = Range.inclusive(1, size).toArray.reverse
+
+  @Benchmark
+  def scalazArrayFill() = {
+    import scalaz.kleisliio.BenchmarkUtils.unsafeRun
+
+    def arrayFill(array: Array[Int]): KleisliIO[Nothing, Int, Int] = {
+      val condition = KleisliIO.lift[Int, Boolean]((i: Int) => i < array.length)
+
+      KleisliIO.whileDo[Nothing, Int](condition)(
+        KleisliIO.impureVoid[Int, Int] { i: Int =>
+          array.update(i, i)
+
+          i + 1
+        })
+    }
+
+    unsafeRun(
+      for {
+        array <- IO.sync[Array[Int]](createTestArray)
+        _ <- arrayFill(array).run(0)
+      } yield ()
+    )
+  }
+  @Benchmark
+  def catsArrayFill() = {
+    import cats.effect.IO
+
+    def arrayFill(array: Array[Int])(i: Int): IO[Unit] =
+      if (i >= array.length) IO.unit
+      else IO(array.update(i, i)).flatMap(_ => arrayFill(array)(i + 1))
+
+    (for {
+      array <- IO(createTestArray)
+      _ <- arrayFill(array)(0)
+    } yield ()).unsafeRunSync()
+  }
+  @Benchmark
+  def monixArrayFill() = {
+    import monix.eval.Task
+    import scalaz.kleisliio.BenchmarkUtils.monixScheduler
+
+    def arrayFill(array: Array[Int])(i: Int): Task[Unit] =
+      if (i >= array.length) Task.unit
+      else Task.eval(array.update(i, i)).flatMap(_ => arrayFill(array)(i + 1))
+
+    (for {
+      array <- Task.eval(createTestArray)
+      _ <- arrayFill(array)(0)
+    } yield ()).runSyncUnsafe(Duration.Inf)
+  }
+}

--- a/benchmarks/src/main/scala/scalaz/kleisliio/BenchmarkUtils.scala
+++ b/benchmarks/src/main/scala/scalaz/kleisliio/BenchmarkUtils.scala
@@ -1,0 +1,31 @@
+package scalaz.kleisliio
+
+import scalaz.zio.RTS
+
+object BenchmarkUtils extends RTS {
+  import monix.execution.Scheduler
+
+  implicit val monixScheduler: Scheduler = {
+    import monix.execution.ExecutionModel.SynchronousExecution
+    Scheduler.computation().withExecutionModel(SynchronousExecution)
+  }
+
+  class Thunk[A](val unsafeRun: () => A) {
+    def map[B](ab: A => B): Thunk[B] =
+      new Thunk(() => ab(unsafeRun()))
+    def flatMap[B](afb: A => Thunk[B]): Thunk[B] =
+      new Thunk(() => afb(unsafeRun()).unsafeRun())
+    def attempt: Thunk[Either[Throwable, A]] =
+      new Thunk(() => {
+        try Right(unsafeRun())
+        catch {
+          case t: Throwable => Left(t)
+        }
+      })
+  }
+  object Thunk {
+    def apply[A](a: => A): Thunk[A] = new Thunk(() => a)
+
+    def fail[A](t: Throwable): Thunk[A] = new Thunk(() => throw t)
+  }
+}

--- a/benchmarks/src/main/scala/scalaz/kleisliio/BenchmarkUtils.scala
+++ b/benchmarks/src/main/scala/scalaz/kleisliio/BenchmarkUtils.scala
@@ -11,10 +11,13 @@ object BenchmarkUtils extends RTS {
   }
 
   class Thunk[A](val unsafeRun: () => A) {
+
     def map[B](ab: A => B): Thunk[B] =
       new Thunk(() => ab(unsafeRun()))
+
     def flatMap[B](afb: A => Thunk[B]): Thunk[B] =
       new Thunk(() => afb(unsafeRun()).unsafeRun())
+
     def attempt: Thunk[Either[Throwable, A]] =
       new Thunk(() => {
         try Right(unsafeRun())
@@ -23,6 +26,7 @@ object BenchmarkUtils extends RTS {
         }
       })
   }
+
   object Thunk {
     def apply[A](a: => A): Thunk[A] = new Thunk(() => a)
 

--- a/benchmarks/src/main/scala/scalaz/kleisliio/BubbleSortBenchmarks.scala
+++ b/benchmarks/src/main/scala/scalaz/kleisliio/BubbleSortBenchmarks.scala
@@ -13,10 +13,12 @@ import scalaz.kleisliio.BenchmarkUtils.unsafeRun
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
 class BubbleSortBenchmarks {
+
   @Param(Array("1000"))
   var size: Int = _
 
   def createTestArray: Array[Int] = Range.inclusive(1, size).toArray.reverse
+
   def assertSorted(array: Array[Int]): Unit =
     if (!array.sorted.sameElements(array)) {
       throw new Exception("Array not correctly sorted")
@@ -29,11 +31,12 @@ class BubbleSortBenchmarks {
     unsafeRun(
       for {
         array <- IO.sync[Array[Int]](createTestArray)
-        _ <- bubbleSort[Int](_ <= _)(array)
-        _ <- IO.sync[Unit](assertSorted(array))
+        _     <- bubbleSort[Int](_ <= _)(array)
+        _     <- IO.sync[Unit](assertSorted(array))
       } yield ()
     )
   }
+
   @Benchmark
   def catsBubbleSort() = {
     import scalaz.kleisliio.CatsIOArray._
@@ -41,10 +44,11 @@ class BubbleSortBenchmarks {
 
     (for {
       array <- IO(createTestArray)
-      _ <- bubbleSort[Int](_ <= _)(array)
-      _ <- IO(assertSorted(array))
+      _     <- bubbleSort[Int](_ <= _)(array)
+      _     <- IO(assertSorted(array))
     } yield ()).unsafeRunSync()
   }
+
   @Benchmark
   def monixBubbleSort() = {
     import scalaz.kleisliio.MonixIOArray._
@@ -53,8 +57,8 @@ class BubbleSortBenchmarks {
 
     (for {
       array <- Task.eval(createTestArray)
-      _ <- bubbleSort[Int](_ <= _)(array)
-      _ <- Task.eval(assertSorted(array))
+      _     <- bubbleSort[Int](_ <= _)(array)
+      _     <- Task.eval(assertSorted(array))
     } yield ()).runSyncUnsafe(Duration.Inf)
   }
 }

--- a/benchmarks/src/main/scala/scalaz/kleisliio/BubbleSortBenchmarks.scala
+++ b/benchmarks/src/main/scala/scalaz/kleisliio/BubbleSortBenchmarks.scala
@@ -1,0 +1,60 @@
+package scalaz.zio
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import scala.concurrent.duration.Duration
+import scala.collection.immutable.Range
+
+import scalaz.kleisliio.BenchmarkUtils.unsafeRun
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class BubbleSortBenchmarks {
+  @Param(Array("1000"))
+  var size: Int = _
+
+  def createTestArray: Array[Int] = Range.inclusive(1, size).toArray.reverse
+  def assertSorted(array: Array[Int]): Unit =
+    if (!array.sorted.sameElements(array)) {
+      throw new Exception("Array not correctly sorted")
+    }
+
+  @Benchmark
+  def scalazBubbleSort() = {
+    import scalaz.kleisliio.ScalazIOArray._
+
+    unsafeRun(
+      for {
+        array <- IO.sync[Array[Int]](createTestArray)
+        _ <- bubbleSort[Int](_ <= _)(array)
+        _ <- IO.sync[Unit](assertSorted(array))
+      } yield ()
+    )
+  }
+  @Benchmark
+  def catsBubbleSort() = {
+    import scalaz.kleisliio.CatsIOArray._
+    import cats.effect.IO
+
+    (for {
+      array <- IO(createTestArray)
+      _ <- bubbleSort[Int](_ <= _)(array)
+      _ <- IO(assertSorted(array))
+    } yield ()).unsafeRunSync()
+  }
+  @Benchmark
+  def monixBubbleSort() = {
+    import scalaz.kleisliio.MonixIOArray._
+    import monix.eval.Task
+    import scalaz.kleisliio.BenchmarkUtils.monixScheduler
+
+    (for {
+      array <- Task.eval(createTestArray)
+      _ <- bubbleSort[Int](_ <= _)(array)
+      _ <- Task.eval(assertSorted(array))
+    } yield ()).runSyncUnsafe(Duration.Inf)
+  }
+}

--- a/benchmarks/src/main/scala/scalaz/kleisliio/KleisliIOBenchmarks.scala
+++ b/benchmarks/src/main/scala/scalaz/kleisliio/KleisliIOBenchmarks.scala
@@ -3,11 +3,10 @@ package scalaz.kleisliio
 object ScalazIOArray {
   import scalaz.zio.IO
 
-  def bubbleSort[A](lessThanEqual0: (A, A) => Boolean)(
-      array: Array[A]): IO[Nothing, Unit] = {
+  def bubbleSort[A](lessThanEqual0: (A, A) => Boolean)(array: Array[A]): IO[Nothing, Unit] = {
 
-    type IndexValue = (Int, A)
-    type IJIndex = (Int, Int)
+    type IndexValue   = (Int, A)
+    type IJIndex      = (Int, Int)
     type IJIndexValue = (IndexValue, IndexValue)
 
     val lessThanEqual =
@@ -61,8 +60,7 @@ object ScalazIOArray {
 object CatsIOArray {
   import cats.effect.IO
 
-  def bubbleSort[A](lessThanEqual0: (A, A) => Boolean)(
-      array: Array[A]): IO[Unit] = {
+  def bubbleSort[A](lessThanEqual0: (A, A) => Boolean)(array: Array[A]): IO[Unit] = {
     def outerLoop(i: Int): IO[Unit] =
       if (i >= array.length - 1) IO.unit
       else innerLoop(i, i + 1).flatMap(_ => outerLoop(i + 1))
@@ -78,7 +76,12 @@ object CatsIOArray {
             maybeSwap.flatMap(_ => innerLoop(i, j + 1))
         }
 
-    def swapIJ(i: Int, ia: A, j: Int, ja: A): IO[Unit] =
+    def swapIJ(
+      i: Int,
+      ia: A,
+      j: Int,
+      ja: A
+    ): IO[Unit] =
       IO { array.update(i, ja); array.update(j, ia) }
 
     outerLoop(0)
@@ -88,8 +91,7 @@ object CatsIOArray {
 object MonixIOArray {
   import monix.eval.Task
 
-  def bubbleSort[A](lessThanEqual0: (A, A) => Boolean)(
-      array: Array[A]): Task[Unit] = {
+  def bubbleSort[A](lessThanEqual0: (A, A) => Boolean)(array: Array[A]): Task[Unit] = {
     def outerLoop(i: Int): Task[Unit] =
       if (i >= array.length - 1) Task.unit
       else innerLoop(i, i + 1).flatMap(_ => outerLoop(i + 1))
@@ -105,7 +107,12 @@ object MonixIOArray {
             maybeSwap.flatMap(_ => innerLoop(i, j + 1))
         }
 
-    def swapIJ(i: Int, ia: A, j: Int, ja: A): Task[Unit] =
+    def swapIJ(
+      i: Int,
+      ia: A,
+      j: Int,
+      ja: A
+    ): Task[Unit] =
       Task.eval { array.update(i, ja); array.update(j, ia) }
 
     outerLoop(0)

--- a/benchmarks/src/main/scala/scalaz/kleisliio/KleisliIOBenchmarks.scala
+++ b/benchmarks/src/main/scala/scalaz/kleisliio/KleisliIOBenchmarks.scala
@@ -1,0 +1,113 @@
+package scalaz.kleisliio
+
+object ScalazIOArray {
+  import scalaz.zio.IO
+
+  def bubbleSort[A](lessThanEqual0: (A, A) => Boolean)(
+      array: Array[A]): IO[Nothing, Unit] = {
+
+    type IndexValue = (Int, A)
+    type IJIndex = (Int, Int)
+    type IJIndexValue = (IndexValue, IndexValue)
+
+    val lessThanEqual =
+      KleisliIO.lift[IJIndexValue, Boolean] {
+        case ((_, ia), (_, ja)) => lessThanEqual0(ia, ja)
+      }
+
+    val extractIJAndIncrementJ = KleisliIO.lift[IJIndexValue, IJIndex] {
+      case ((i, _), (j, _)) => (i, j + 1)
+    }
+
+    val extractIAndIncrementI = KleisliIO.lift[IJIndex, Int](_._1 + 1)
+
+    val innerLoopStart = KleisliIO.lift[Int, IJIndex]((i: Int) => (i, i + 1))
+
+    val outerLoopCheck: KleisliIO[Nothing, Int, Boolean] =
+      KleisliIO.lift((i: Int) => i < array.length - 1)
+
+    val innerLoopCheck: KleisliIO[Nothing, IJIndex, Boolean] =
+      KleisliIO.lift { case (_, j) => j < array.length }
+
+    val extractIJIndexValue: KleisliIO[Nothing, IJIndex, IJIndexValue] =
+      KleisliIO.impureVoid {
+        case (i, j) => ((i, array(i)), (j, array(j)))
+      }
+
+    val swapIJ: KleisliIO[Nothing, IJIndexValue, IJIndexValue] =
+      KleisliIO.impureVoid {
+        case v @ ((i, ia), (j, ja)) =>
+          array.update(i, ja)
+          array.update(j, ia)
+
+          v
+      }
+
+    val sort = KleisliIO
+      .whileDo[Nothing, Int](outerLoopCheck)(
+        innerLoopStart >>>
+          KleisliIO.whileDo[Nothing, IJIndex](innerLoopCheck)(
+            extractIJIndexValue >>>
+              KleisliIO
+                .ifNotThen[Nothing, IJIndexValue](lessThanEqual)(swapIJ) >>>
+              extractIJAndIncrementJ
+          ) >>>
+          extractIAndIncrementI
+      )
+    sort.run(0).toUnit
+  }
+}
+
+object CatsIOArray {
+  import cats.effect.IO
+
+  def bubbleSort[A](lessThanEqual0: (A, A) => Boolean)(
+      array: Array[A]): IO[Unit] = {
+    def outerLoop(i: Int): IO[Unit] =
+      if (i >= array.length - 1) IO.unit
+      else innerLoop(i, i + 1).flatMap(_ => outerLoop(i + 1))
+
+    def innerLoop(i: Int, j: Int): IO[Unit] =
+      if (j >= array.length) IO.unit
+      else
+        IO((array(i), array(j))).flatMap {
+          case (ia, ja) =>
+            val maybeSwap =
+              if (lessThanEqual0(ia, ja)) IO.unit else swapIJ(i, ia, j, ja)
+
+            maybeSwap.flatMap(_ => innerLoop(i, j + 1))
+        }
+
+    def swapIJ(i: Int, ia: A, j: Int, ja: A): IO[Unit] =
+      IO { array.update(i, ja); array.update(j, ia) }
+
+    outerLoop(0)
+  }
+}
+
+object MonixIOArray {
+  import monix.eval.Task
+
+  def bubbleSort[A](lessThanEqual0: (A, A) => Boolean)(
+      array: Array[A]): Task[Unit] = {
+    def outerLoop(i: Int): Task[Unit] =
+      if (i >= array.length - 1) Task.unit
+      else innerLoop(i, i + 1).flatMap(_ => outerLoop(i + 1))
+
+    def innerLoop(i: Int, j: Int): Task[Unit] =
+      if (j >= array.length) Task.unit
+      else
+        Task.eval((array(i), array(j))).flatMap {
+          case (ia, ja) =>
+            val maybeSwap =
+              if (lessThanEqual0(ia, ja)) Task.unit else swapIJ(i, ia, j, ja)
+
+            maybeSwap.flatMap(_ => innerLoop(i, j + 1))
+        }
+
+    def swapIJ(i: Int, ia: A, j: Int, ja: A): Task[Unit] =
+      Task.eval { array.update(i, ja); array.update(j, ia) }
+
+    outerLoop(0)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -17,22 +17,17 @@ dynverSonatypeSnapshots in ThisBuild := true
 lazy val sonataCredentials = for {
   username <- sys.env.get("SONATYPE_USERNAME")
   password <- sys.env.get("SONATYPE_PASSWORD")
-} yield
-  Credentials("Sonatype Nexus Repository Manager",
-              "oss.sonatype.org",
-              username,
-              password)
+} yield Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password)
 
 credentials in ThisBuild ++= sonataCredentials.toSeq
 
 lazy val scalazDependencies = Seq(
   "org.scalaz" %% "scalaz-core" % "7.2.25",
-  "org.scalaz" %% "scalaz-zio" % "0.1-SNAPSHOT"
+  "org.scalaz" %% "scalaz-zio"  % "0.1-SNAPSHOT"
 )
 
 lazy val core = project
   .settings(
-
     // In the repl most warnings are useless or worse.
     // This is intentionally := as it's more direct to enumerate the few
     // options we do want than to try to subtract off the ones we don't.
@@ -58,8 +53,8 @@ lazy val core = project
       val prod = Seq() ++ scalazDependencies
 
       val test = Seq(
-        "org.specs2" %% "specs2-core" % "4.3.2",
-        "org.specs2" %% "specs2-scalacheck" % "4.3.2",
+        "org.specs2" %% "specs2-core"          % "4.3.2",
+        "org.specs2" %% "specs2-scalacheck"    % "4.3.2",
         "org.specs2" %% "specs2-matcher-extra" % "4.3.2"
       ).map(_ % Test)
 
@@ -75,16 +70,15 @@ lazy val benchmarks = project
     skip in publish := true,
     libraryDependencies ++=
       Seq(
-        "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+        "org.scala-lang" % "scala-reflect"  % scalaVersion.value,
         "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
-        "io.monix" %% "monix" % "3.0.0-RC1",
-        "org.typelevel" %% "cats-effect" % "1.0.0-RC2"
+        "io.monix"       %% "monix"         % "3.0.0-RC1",
+        "org.typelevel"  %% "cats-effect"   % "1.0.0-RC2"
       ) ++ scalazDependencies
   )
 
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
-addCommandAlias("check",
-                "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
+addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
 
 lazy val root =
   (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val core = project
                                                |import replRTS._
                                              """.stripMargin,
     libraryDependencies ++= {
-      val prod = Seq() ++ scalazDependencies
+      val prod = scalazDependencies
 
       val test = Seq(
         "org.specs2" %% "specs2-core"          % "4.3.2",
@@ -74,7 +74,7 @@ lazy val benchmarks = project
         "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
         "io.monix"       %% "monix"         % "3.0.0-RC1",
         "org.typelevel"  %% "cats-effect"   % "1.0.0-RC2"
-      ) ++ scalazDependencies
+      )
   )
 
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")

--- a/build.sbt
+++ b/build.sbt
@@ -17,15 +17,76 @@ dynverSonatypeSnapshots in ThisBuild := true
 lazy val sonataCredentials = for {
   username <- sys.env.get("SONATYPE_USERNAME")
   password <- sys.env.get("SONATYPE_PASSWORD")
-} yield Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password)
+} yield
+  Credentials("Sonatype Nexus Repository Manager",
+              "oss.sonatype.org",
+              username,
+              password)
 
 credentials in ThisBuild ++= sonataCredentials.toSeq
 
+lazy val scalazDependencies = Seq(
+  "org.scalaz" %% "scalaz-core" % "7.2.25",
+  "org.scalaz" %% "scalaz-zio" % "0.1-SNAPSHOT"
+)
+
+lazy val core = project
+  .settings(
+
+    // In the repl most warnings are useless or worse.
+    // This is intentionally := as it's more direct to enumerate the few
+    // options we do want than to try to subtract off the ones we don't.
+    // One of -Ydelambdafy:inline or -Yrepl-class-based must be given to
+    // avoid deadlocking on parallel operations, see
+    //   https://issues.scala-lang.org/browse/SI-9076
+    scalacOptions in Compile in console := Seq(
+      "-Ypartial-unification",
+      "-language:higherKinds",
+      "-language:existentials",
+      "-Yno-adapted-args",
+      "-Xsource:2.13",
+      "-Yrepl-class-based"
+    ),
+    resolvers += Resolver.sonatypeRepo("snapshots"),
+    initialCommands in Compile in console := """
+                                               |import scalaz._
+                                               |import scalaz.zio._
+                                               |object replRTS extends RTS {}
+                                               |import replRTS._
+                                             """.stripMargin,
+    libraryDependencies ++= {
+      val prod = Seq() ++ scalazDependencies
+
+      val test = Seq(
+        "org.specs2" %% "specs2-core" % "4.3.2",
+        "org.specs2" %% "specs2-scalacheck" % "4.3.2",
+        "org.specs2" %% "specs2-matcher-extra" % "4.3.2"
+      ).map(_ % Test)
+
+      prod ++ test
+    }
+  )
+
+lazy val benchmarks = project
+  .dependsOn(core)
+  .enablePlugins(JmhPlugin)
+  .settings(
+    resolvers += Resolver.sonatypeRepo("snapshots"),
+    skip in publish := true,
+    libraryDependencies ++=
+      Seq(
+        "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+        "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
+        "io.monix" %% "monix" % "3.0.0-RC1",
+        "org.typelevel" %% "cats-effect" % "1.0.0-RC2"
+      ) ++ scalazDependencies
+  )
+
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
-addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
+addCommandAlias("check",
+                "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
 
 lazy val root =
   (project in file("."))
-    .settings(
-      stdSettings("kleisliio")
-    )
+    .settings(stdSettings("kleisliio"))
+    .aggregate(core, benchmarks)

--- a/build.sbt
+++ b/build.sbt
@@ -21,11 +21,6 @@ lazy val sonataCredentials = for {
 
 credentials in ThisBuild ++= sonataCredentials.toSeq
 
-lazy val scalazDependencies = Seq(
-  "org.scalaz" %% "scalaz-core" % "7.2.25",
-  "org.scalaz" %% "scalaz-zio"  % "0.1-SNAPSHOT"
-)
-
 lazy val core = project
   .settings(
     // In the repl most warnings are useless or worse.
@@ -50,7 +45,8 @@ lazy val core = project
                                                |import replRTS._
                                              """.stripMargin,
     libraryDependencies ++= {
-      val prod = scalazDependencies
+      val prod =
+        Seq("org.scalaz" %% "scalaz-core" % "7.2.25", "org.scalaz" %% "scalaz-zio" % "0.1-SNAPSHOT")
 
       val test = Seq(
         "org.specs2" %% "specs2-core"          % "4.3.2",

--- a/core/src/main/scala/scalaz/kleisliio/KleisliIO.scala
+++ b/core/src/main/scala/scalaz/kleisliio/KleisliIO.scala
@@ -3,303 +3,305 @@ package scalaz.kleisliio
 import scalaz.zio.IO
 
 /**
-  * A `KleisliIO[E, A, B]` is an effectful function from `A` to `B`, which might
-  * fail with an `E`.
-  *
-  * This is the moral equivalent of `A => IO[E, B]`, and, indeed, `KleisliIO`
-  * extends this function type, and can be used in the same way.
-  *
-  * The main advantage to using `KleisliIO` is that it provides you a means of
-  * importing an impure function `A => B` into `KleisliIO[E, A, B]`, without
-  * actually wrapping the result of the function in an `IO` value.
-  *
-  * This allows the implementation to aggressively fuse operations on impure
-  * functions, which in turn can result in significantly higher-performance and
-  * far less heap utilization than equivalent approaches modeled with `IO`.
-  *
-  * The implementation allows you to lift functions from `A => IO[E, B]` into a
-  * `KleisliIO[E, A, B]`. Such functions cannot be optimized, but will be handled
-  * correctly and can work in conjunction with optimized (fused) `KleisliIO`.
-  *
-  * Those interested in learning more about modeling effects with `KleisliIO` are
-  * encouraged to read John Hughes paper on the subject: Generalizing Monads to
-  * Arrows (www.cse.chalmers.se/~rjmh/Papers/arrows.pdf). The implementation in
-  * this file contains many of the same combinators as Hughes implementation.
-  *
-  * A word of warning: while even very complex code can be expressed in
-  * `KleisliIO`, there is a point of diminishing return. If you find yourself
-  * using deeply nested tuples to propagate information forward, it may be no
-  * faster than using `IO`.
-  *
-  * Given the following two `KleisliIO`:
-  *
-  * {{{
-  * val readLine = KleisliIO.impureVoid((_ : Unit) => scala.Console.readLine())
-  * val printLine = KleisliIO.impureVoid((line: String) => println(line))
-  * }}}
-  *
-  * Then the following two programs are equivalent:
-  *
-  * {{{
-  * // Program 1
-  * val program1: IO[Nothing, Unit] =
-  *   for {
-  *     name <- getStrLn
-  *     _    <- putStrLn("Hello, " + name)
-  *   } yield ())
-  *
-  * // Program 2
-  * val program2: IO[Nothing, Unit] = (readLine >>> KleisliIO.lift("Hello, " + _) >>> printLine)(())
-  * }}}
-  *
-  * Similarly, the following two programs are equivalent:
-  *
-  * {{{
-  * // Program 1
-  * val program1: IO[Nothing, Unit] =
-  *   for {
-  *     line1 <- getStrLn
-  *     line2 <- getStrLn
-  *     _     <- putStrLn("You wrote: " + line1 + ", " + line2)
-  *   } yield ())
-  *
-  * // Program 2
-  * val program2: IO[Nothing, Unit] =
-  *   (readLine.zipWith(readLine)("You wrote: " + _ + ", " + _) >>> printLine)(())
-  * }}}
-  *
-  * In both of these examples, the `KleisliIO` program is faster because it is
-  * able to perform fusion of effectful functions.
-  */
-sealed trait KleisliIO[+E, -A, +B] { self =>
+ * A `KleisliIO[E, A, B]` is an effectful function from `A` to `B`, which might
+ * fail with an `E`.
+ *
+ * This is the moral equivalent of `A => IO[E, B]`, and, indeed, `KleisliIO`
+ * extends this function type, and can be used in the same way.
+ *
+ * The main advantage to using `KleisliIO` is that it provides you a means of
+ * importing an impure function `A => B` into `KleisliIO[E, A, B]`, without
+ * actually wrapping the result of the function in an `IO` value.
+ *
+ * This allows the implementation to aggressively fuse operations on impure
+ * functions, which in turn can result in significantly higher-performance and
+ * far less heap utilization than equivalent approaches modeled with `IO`.
+ *
+ * The implementation allows you to lift functions from `A => IO[E, B]` into a
+ * `KleisliIO[E, A, B]`. Such functions cannot be optimized, but will be handled
+ * correctly and can work in conjunction with optimized (fused) `KleisliIO`.
+ *
+ * Those interested in learning more about modeling effects with `KleisliIO` are
+ * encouraged to read John Hughes paper on the subject: Generalizing Monads to
+ * Arrows (www.cse.chalmers.se/~rjmh/Papers/arrows.pdf). The implementation in
+ * this file contains many of the same combinators as Hughes implementation.
+ *
+ * A word of warning: while even very complex code can be expressed in
+ * `KleisliIO`, there is a point of diminishing return. If you find yourself
+ * using deeply nested tuples to propagate information forward, it may be no
+ * faster than using `IO`.
+ *
+ * Given the following two `KleisliIO`:
+ *
+ * {{{
+ * val readLine = KleisliIO.impureVoid((_ : Unit) => scala.Console.readLine())
+ * val printLine = KleisliIO.impureVoid((line: String) => println(line))
+ * }}}
+ *
+ * Then the following two programs are equivalent:
+ *
+ * {{{
+ * // Program 1
+ * val program1: IO[Nothing, Unit] =
+ *   for {
+ *     name <- getStrLn
+ *     _    <- putStrLn("Hello, " + name)
+ *   } yield ())
+ *
+ * // Program 2
+ * val program2: IO[Nothing, Unit] = (readLine >>> KleisliIO.lift("Hello, " + _) >>> printLine)(())
+ * }}}
+ *
+ * Similarly, the following two programs are equivalent:
+ *
+ * {{{
+ * // Program 1
+ * val program1: IO[Nothing, Unit] =
+ *   for {
+ *     line1 <- getStrLn
+ *     line2 <- getStrLn
+ *     _     <- putStrLn("You wrote: " + line1 + ", " + line2)
+ *   } yield ())
+ *
+ * // Program 2
+ * val program2: IO[Nothing, Unit] =
+ *   (readLine.zipWith(readLine)("You wrote: " + _ + ", " + _) >>> printLine)(())
+ * }}}
+ *
+ * In both of these examples, the `KleisliIO` program is faster because it is
+ * able to perform fusion of effectful functions.
+ */
+sealed trait KleisliIO[+E, -A, +B] {
+  self =>
 
   /**
-    * Applies the effectful function with the specified value, returning the
-    * output in `IO`.
-    */
+   * Applies the effectful function with the specified value, returning the
+   * output in `IO`.
+   */
   val run: A => IO[E, B]
 
   /**
-    * Maps the output of this effectful function by the specified function.
-    */
+   * Maps the output of this effectful function by the specified function.
+   */
   final def map[C](f: B => C): KleisliIO[E, A, C] = self >>> KleisliIO.lift(f)
 
   /**
-    * Binds on the output of this effectful function.
-    */
-  final def flatMap[E1 >: E, A1 <: A, C](
-      f: B => KleisliIO[E1, A1, C]): KleisliIO[E1, A1, C] =
+   * Binds on the output of this effectful function.
+   */
+  final def flatMap[E1 >: E, A1 <: A, C](f: B => KleisliIO[E1, A1, C]): KleisliIO[E1, A1, C] =
     KleisliIO.flatMap(self, f)
 
   /**
-    * Composes two effectful functions.
-    */
-  final def compose[E1 >: E, A0](
-      that: KleisliIO[E1, A0, A]): KleisliIO[E1, A0, B] =
+   * Composes two effectful functions.
+   */
+  final def compose[E1 >: E, A0](that: KleisliIO[E1, A0, A]): KleisliIO[E1, A0, B] =
     KleisliIO.compose(self, that)
 
   /**
-    * "Backwards" composition of effectful functions.
-    */
-  final def andThen[E1 >: E, C](
-      that: KleisliIO[E1, B, C]): KleisliIO[E1, A, C] =
+   * "Backwards" composition of effectful functions.
+   */
+  final def andThen[E1 >: E, C](that: KleisliIO[E1, B, C]): KleisliIO[E1, A, C] =
     that.compose(self)
 
   /**
-    * A symbolic operator for `andThen`.
-    */
-  final def >>>[E1 >: E, C](that: KleisliIO[E1, B, C]): KleisliIO[E1, A, C] =
+   * A symbolic operator for `andThen`.
+   */
+  final def >>> [E1 >: E, C](that: KleisliIO[E1, B, C]): KleisliIO[E1, A, C] =
     self.andThen(that)
 
   /**
-    * A symbolic operator for `compose`.
-    */
-  final def <<<[E1 >: E, C](that: KleisliIO[E1, C, A]): KleisliIO[E1, C, B] =
+   * A symbolic operator for `compose`.
+   */
+  final def <<< [E1 >: E, C](that: KleisliIO[E1, C, A]): KleisliIO[E1, C, B] =
     self.compose(that)
 
   /**
-    * Zips the output of this function with the output of that function, using
-    * the specified combiner function.
-    */
-  final def zipWith[E1 >: E, A1 <: A, C, D](that: KleisliIO[E1, A1, C])(
-      f: (B, C) => D): KleisliIO[E1, A1, D] =
+   * Zips the output of this function with the output of that function, using
+   * the specified combiner function.
+   */
+  final def zipWith[E1 >: E, A1 <: A, C, D](
+    that: KleisliIO[E1, A1, C]
+  )(
+    f: (B, C) => D
+  ): KleisliIO[E1, A1, D] =
     KleisliIO.zipWith(self, that)(f)
 
   /**
-    * Returns a new effectful function that computes the value of this function,
-    * storing it into the first element of a tuple, carrying along the input on
-    * the second element of a tuple.
-    */
+   * Returns a new effectful function that computes the value of this function,
+   * storing it into the first element of a tuple, carrying along the input on
+   * the second element of a tuple.
+   */
   final def first[A1 <: A, B1 >: B]: KleisliIO[E, A1, (B1, A1)] =
     self &&& KleisliIO.identity[A1]
 
   /**
-    * Returns a new effectful function that computes the value of this function,
-    * storing it into the second element of a tuple, carrying along the input on
-    * the first element of a tuple.
-    */
+   * Returns a new effectful function that computes the value of this function,
+   * storing it into the second element of a tuple, carrying along the input on
+   * the first element of a tuple.
+   */
   final def second[A1 <: A, B1 >: B]: KleisliIO[E, A1, (A1, B1)] =
     KleisliIO.identity[A1] &&& self
 
   /**
-    * Returns a new effectful function that can either compute the value of this
-    * effectful function (if passed `Left(a)`), or can carry along any other
-    * `C` value (if passed `Right(c)`).
-    */
+   * Returns a new effectful function that can either compute the value of this
+   * effectful function (if passed `Left(a)`), or can carry along any other
+   * `C` value (if passed `Right(c)`).
+   */
   final def left[C]: KleisliIO[E, Either[A, C], Either[B, C]] =
     KleisliIO.left(self)
 
   /**
-    * Returns a new effectful function that can either compute the value of this
-    * effectful function (if passed `Right(a)`), or can carry along any other
-    * `C` value (if passed `Left(c)`).
-    */
+   * Returns a new effectful function that can either compute the value of this
+   * effectful function (if passed `Right(a)`), or can carry along any other
+   * `C` value (if passed `Left(c)`).
+   */
   final def right[C]: KleisliIO[E, Either[C, A], Either[C, B]] =
     KleisliIO.right(self)
 
   /**
-    * Returns a new effectful function that zips together the output of two
-    * effectful functions that share the same input.
-    */
-  final def &&&[E1 >: E, A1 <: A, C](
-      that: KleisliIO[E1, A1, C]): KleisliIO[E1, A1, (B, C)] =
+   * Returns a new effectful function that zips together the output of two
+   * effectful functions that share the same input.
+   */
+  final def &&& [E1 >: E, A1 <: A, C](that: KleisliIO[E1, A1, C]): KleisliIO[E1, A1, (B, C)] =
     KleisliIO.zipWith(self, that)((a, b) => (a, b))
 
   /**
-    * Returns a new effectful function that will either compute the value of this
-    * effectful function (if passed `Left(a)`), or will compute the value of the
-    * specified effectful function (if passed `Right(c)`).
-    */
-  final def |||[E1 >: E, B1 >: B, C](
-      that: KleisliIO[E1, C, B1]): KleisliIO[E1, Either[A, C], B1] =
+   * Returns a new effectful function that will either compute the value of this
+   * effectful function (if passed `Left(a)`), or will compute the value of the
+   * specified effectful function (if passed `Right(c)`).
+   */
+  final def ||| [E1 >: E, B1 >: B, C](that: KleisliIO[E1, C, B1]): KleisliIO[E1, Either[A, C], B1] =
     KleisliIO.join(self, that)
 
   /**
-    * Maps the output of this effectful function to the specified constant.
-    */
+   * Maps the output of this effectful function to the specified constant.
+   */
   final def const[C](c: => C): KleisliIO[E, A, C] =
     self >>> KleisliIO.lift[B, C](_ => c)
 
   /**
-    * Maps the output of this effectful function to `Unit`.
-    */
+   * Maps the output of this effectful function to `Unit`.
+   */
   final def toUnit: KleisliIO[E, A, Unit] = const(())
 
   /**
-    * Returns a new effectful function that merely applies this one for its
-    * effect, returning the input unmodified.
-    */
+   * Returns a new effectful function that merely applies this one for its
+   * effect, returning the input unmodified.
+   */
   final def asEffect[A1 <: A]: KleisliIO[E, A1, A1] =
     self.first >>> KleisliIO._2
 }
 
 object KleisliIO {
+
   private class KleisliIOError[E](error: E) extends Throwable {
     final def unsafeCoerce[E2] = error.asInstanceOf[E2]
   }
 
-  private[kleisliio] final class Pure[E, A, B](val run: A => IO[E, B])
-      extends KleisliIO[E, A, B] {}
-  private[kleisliio] final class Impure[E, A, B](val apply0: A => B)
-      extends KleisliIO[E, A, B] {
+  final private[kleisliio] class Pure[E, A, B](val run: A => IO[E, B]) extends KleisliIO[E, A, B] {}
+
+  final private[kleisliio] class Impure[E, A, B](val apply0: A => B) extends KleisliIO[E, A, B] {
+
     val run: A => IO[E, B] = a =>
       IO.suspend {
         try IO.now[B](apply0(a))
         catch {
           case e: KleisliIOError[_] => IO.fail[E](e.unsafeCoerce[E])
         }
-    }
+      }
   }
 
   /**
-    * Lifts a value into the monad formed by `KleisliIO`.
-    */
+   * Lifts a value into the monad formed by `KleisliIO`.
+   */
   final def point[B](b: => B): KleisliIO[Nothing, Any, B] = lift((_: Any) => b)
 
   /**
-    * Returns a `KleisliIO` representing a failure with the specified `E`.
-    */
+   * Returns a `KleisliIO` representing a failure with the specified `E`.
+   */
   final def fail[E](e: E): KleisliIO[E, Any, Nothing] =
     new Impure(_ => throw new KleisliIOError[E](e))
 
   /**
-    * Returns the identity effectful function, which performs no effects and
-    * merely returns its input unmodified.
-    */
+   * Returns the identity effectful function, which performs no effects and
+   * merely returns its input unmodified.
+   */
   final def identity[A]: KleisliIO[Nothing, A, A] = lift(a => a)
 
   /**
-    * Lifts a pure `A => IO[E, B]` into `KleisliIO`.
-    */
+   * Lifts a pure `A => IO[E, B]` into `KleisliIO`.
+   */
   final def pure[E, A, B](f: A => IO[E, B]): KleisliIO[E, A, B] = new Pure(f)
 
   /**
-    * Lifts a pure `A => B` into `KleisliIO`.
-    */
+   * Lifts a pure `A => B` into `KleisliIO`.
+   */
   final def lift[A, B](f: A => B): KleisliIO[Nothing, A, B] = new Impure(f)
 
   /**
-    * Returns an effectful function that merely swaps the elements in a `Tuple2`.
-    */
+   * Returns an effectful function that merely swaps the elements in a `Tuple2`.
+   */
   final def swap[E, A, B]: KleisliIO[E, (A, B), (B, A)] =
     KleisliIO.lift[(A, B), (B, A)](_.swap)
 
   /**
-    * Lifts an impure function into `KleisliIO`, converting throwables into the
-    * specified error type `E`.
-    */
-  final def impure[E, A, B](catcher: PartialFunction[Throwable, E])(
-      f: A => B): KleisliIO[E, A, B] =
+   * Lifts an impure function into `KleisliIO`, converting throwables into the
+   * specified error type `E`.
+   */
+  final def impure[E, A, B](catcher: PartialFunction[Throwable, E])(f: A => B): KleisliIO[E, A, B] =
     new Impure(
       (a: A) =>
         try f(a)
         catch {
           case t: Throwable if catcher.isDefinedAt(t) =>
             throw new KleisliIOError(catcher(t))
-      }
+        }
     )
 
   /**
-    * Lifts an impure function into `KleisliIO`, assuming any throwables are
-    * non-recoverable and do not need to be converted into errors.
-    */
+   * Lifts an impure function into `KleisliIO`, assuming any throwables are
+   * non-recoverable and do not need to be converted into errors.
+   */
   final def impureVoid[A, B](f: A => B): KleisliIO[Nothing, A, B] =
     new Impure(f)
 
   /**
-    * Returns a new effectful function that passes an `A` to the condition, and
-    * if the condition returns true, returns `Left(a)`, but if the condition
-    * returns false, returns `Right(a)`.
-    */
-  final def test[E, A](
-      k: KleisliIO[E, A, Boolean]): KleisliIO[E, A, Either[A, A]] =
+   * Returns a new effectful function that passes an `A` to the condition, and
+   * if the condition returns true, returns `Left(a)`, but if the condition
+   * returns false, returns `Right(a)`.
+   */
+  final def test[E, A](k: KleisliIO[E, A, Boolean]): KleisliIO[E, A, Either[A, A]] =
     (k &&& KleisliIO.identity[A]) >>>
       KleisliIO.lift((t: (Boolean, A)) => if (t._1) Left(t._2) else Right(t._2))
 
   /**
-    * Returns a new effectful function that passes an `A` to the condition, and
-    * if the condition returns true, passes the `A` to the `then0` function,
-    * but if the condition returns false, passes the `A` to the `else0` function.
-    */
+   * Returns a new effectful function that passes an `A` to the condition, and
+   * if the condition returns true, passes the `A` to the `then0` function,
+   * but if the condition returns false, passes the `A` to the `else0` function.
+   */
   final def ifThenElse[E, A, B](
-      cond: KleisliIO[E, A, Boolean]
-  )(then0: KleisliIO[E, A, B])(else0: KleisliIO[E, A, B]): KleisliIO[E, A, B] =
+    cond: KleisliIO[E, A, Boolean]
+  )(
+    then0: KleisliIO[E, A, B]
+  )(
+    else0: KleisliIO[E, A, B]
+  ): KleisliIO[E, A, B] =
     (cond, then0, else0) match {
-      case (cond: Impure[_, _, _],
-            then0: Impure[_, _, _],
-            else0: Impure[_, _, _]) =>
-        new Impure[E, A, B](a =>
-          if (cond.apply0(a)) then0.apply0(a) else else0.apply0(a))
+      case (cond: Impure[_, _, _], then0: Impure[_, _, _], else0: Impure[_, _, _]) =>
+        new Impure[E, A, B](a => if (cond.apply0(a)) then0.apply0(a) else else0.apply0(a))
       case _ => test[E, A](cond) >>> (then0 ||| else0)
     }
 
   /**
-    * Returns a new effectful function that passes an `A` to the condition, and
-    * if the condition returns true, passes the `A` to the `then0` function, but
-    * otherwise returns the original `A` unmodified.
-    */
-  final def ifThen[E, A](cond: KleisliIO[E, A, Boolean])(
-      then0: KleisliIO[E, A, A]): KleisliIO[E, A, A] =
+   * Returns a new effectful function that passes an `A` to the condition, and
+   * if the condition returns true, passes the `A` to the `then0` function, but
+   * otherwise returns the original `A` unmodified.
+   */
+  final def ifThen[E, A](
+    cond: KleisliIO[E, A, Boolean]
+  )(
+    then0: KleisliIO[E, A, A]
+  ): KleisliIO[E, A, A] =
     (cond, then0) match {
       case (cond: Impure[_, _, _], then0: Impure[_, _, _]) =>
         new Impure[E, A, A](a => if (cond.apply0(a)) then0.apply0(a) else a)
@@ -307,12 +309,15 @@ object KleisliIO {
     }
 
   /**
-    * Returns a new effectful function that passes an `A` to the condition, and
-    * if the condition returns false, passes the `A` to the `then0` function, but
-    * otherwise returns the original `A` unmodified.
-    */
-  final def ifNotThen[E, A](cond: KleisliIO[E, A, Boolean])(
-      then0: KleisliIO[E, A, A]): KleisliIO[E, A, A] =
+   * Returns a new effectful function that passes an `A` to the condition, and
+   * if the condition returns false, passes the `A` to the `then0` function, but
+   * otherwise returns the original `A` unmodified.
+   */
+  final def ifNotThen[E, A](
+    cond: KleisliIO[E, A, Boolean]
+  )(
+    then0: KleisliIO[E, A, A]
+  ): KleisliIO[E, A, A] =
     (cond, then0) match {
       case (cond: Impure[_, _, _], then0: Impure[_, _, _]) =>
         new Impure[E, A, A](a => if (cond.apply0(a)) a else then0.apply0(a))
@@ -320,19 +325,22 @@ object KleisliIO {
     }
 
   /**
-    * Returns a new effectful function that passes an `A` to the condition, and
-    * if the condition returns true, passes the `A` through the body to yield a
-    * new `A`, which repeats until the condition returns false. This is the
-    * `KleisliIO` equivalent of a `while(cond) { body }` loop.
-    */
-  final def whileDo[E, A](check: KleisliIO[E, A, Boolean])(
-      body: KleisliIO[E, A, A]): KleisliIO[E, A, A] =
+   * Returns a new effectful function that passes an `A` to the condition, and
+   * if the condition returns true, passes the `A` through the body to yield a
+   * new `A`, which repeats until the condition returns false. This is the
+   * `KleisliIO` equivalent of a `while(cond) { body }` loop.
+   */
+  final def whileDo[E, A](
+    check: KleisliIO[E, A, Boolean]
+  )(
+    body: KleisliIO[E, A, A]
+  ): KleisliIO[E, A, A] =
     (check, body) match {
       case (check: Impure[_, _, _], body: Impure[_, _, _]) =>
         new Impure[E, A, A]({ a0: A =>
           var a = a0
 
-          val cond = check.apply0
+          val cond   = check.apply0
           val update = body.apply0
 
           while (cond(a)) {
@@ -348,38 +356,40 @@ object KleisliIO {
             (a: A) =>
               check
                 .run(a)
-                .flatMap((b: Boolean) =>
-                  if (b) body.run(a).flatMap(loop.run) else IO.now(a))
+                .flatMap((b: Boolean) => if (b) body.run(a).flatMap(loop.run) else IO.now(a))
           )
 
         loop
     }
 
   /**
-    * Returns an effectful function that extracts out the first element of a
-    * tuple.
-    */
+   * Returns an effectful function that extracts out the first element of a
+   * tuple.
+   */
   final def _1[E, A, B]: KleisliIO[E, (A, B), A] = lift[(A, B), A](_._1)
 
   /**
-    * Returns an effectful function that extracts out the second element of a
-    * tuple.
-    */
+   * Returns an effectful function that extracts out the second element of a
+   * tuple.
+   */
   final def _2[E, A, B]: KleisliIO[E, (A, B), B] = lift[(A, B), B](_._2)
 
   /**
-    * See @KleisliIO.flatMap
-    */
+   * See @KleisliIO.flatMap
+   */
   final def flatMap[E, A, B, C](
-      fa: KleisliIO[E, A, B],
-      f: B => KleisliIO[E, A, C]): KleisliIO[E, A, C] =
+    fa: KleisliIO[E, A, B],
+    f: B => KleisliIO[E, A, C]
+  ): KleisliIO[E, A, C] =
     new Pure((a: A) => fa.run(a).flatMap(b => f(b).run(a)))
 
   /**
-    * See KleisliIO.compose
-    */
-  final def compose[E, A, B, C](second: KleisliIO[E, B, C],
-                                first: KleisliIO[E, A, B]): KleisliIO[E, A, C] =
+   * See KleisliIO.compose
+   */
+  final def compose[E, A, B, C](
+    second: KleisliIO[E, B, C],
+    first: KleisliIO[E, A, B]
+  ): KleisliIO[E, A, C] =
     (second, first) match {
       case (second: Impure[_, _, _], first: Impure[_, _, _]) =>
         new Impure(second.apply0.compose(first.apply0))
@@ -389,11 +399,14 @@ object KleisliIO {
     }
 
   /**
-    * See KleisliIO.zipWith
-    */
+   * See KleisliIO.zipWith
+   */
   final def zipWith[E, A, B, C, D](
-      l: KleisliIO[E, A, B],
-      r: KleisliIO[E, A, C])(f: (B, C) => D): KleisliIO[E, A, D] =
+    l: KleisliIO[E, A, B],
+    r: KleisliIO[E, A, C]
+  )(
+    f: (B, C) => D
+  ): KleisliIO[E, A, D] =
     (l, r) match {
       case (l: Impure[_, _, _], r: Impure[_, _, _]) =>
         new Impure((a: A) => {
@@ -414,10 +427,9 @@ object KleisliIO {
     }
 
   /**
-    * See KleisliIO.left
-    */
-  final def left[E, A, B, C](
-      k: KleisliIO[E, A, B]): KleisliIO[E, Either[A, C], Either[B, C]] =
+   * See KleisliIO.left
+   */
+  final def left[E, A, B, C](k: KleisliIO[E, A, B]): KleisliIO[E, Either[A, C], Either[B, C]] =
     k match {
       case k: Impure[E, A, B] =>
         new Impure[E, Either[A, C], Either[B, C]]({
@@ -432,10 +444,9 @@ object KleisliIO {
     }
 
   /**
-    * See KleisliIO.left
-    */
-  final def right[E, A, B, C](
-      k: KleisliIO[E, A, B]): KleisliIO[E, Either[C, A], Either[C, B]] =
+   * See KleisliIO.left
+   */
+  final def right[E, A, B, C](k: KleisliIO[E, A, B]): KleisliIO[E, Either[C, A], Either[C, B]] =
     k match {
       case k: Impure[E, A, B] =>
         new Impure[E, Either[C, A], Either[C, B]]({
@@ -450,11 +461,12 @@ object KleisliIO {
     }
 
   /**
-    * See KleisliIO.|||
-    */
+   * See KleisliIO.|||
+   */
   final def join[E, A, B, C](
-      l: KleisliIO[E, A, B],
-      r: KleisliIO[E, C, B]): KleisliIO[E, Either[A, C], B] =
+    l: KleisliIO[E, A, B],
+    r: KleisliIO[E, C, B]
+  ): KleisliIO[E, Either[A, C], B] =
     (l, r) match {
       case (l: Impure[_, _, _], r: Impure[_, _, _]) =>
         new Impure[E, Either[A, C], B]({

--- a/core/src/main/scala/scalaz/kleisliio/KleisliIO.scala
+++ b/core/src/main/scala/scalaz/kleisliio/KleisliIO.scala
@@ -1,0 +1,471 @@
+package scalaz.kleisliio
+
+import scalaz.zio.IO
+
+/**
+  * A `KleisliIO[E, A, B]` is an effectful function from `A` to `B`, which might
+  * fail with an `E`.
+  *
+  * This is the moral equivalent of `A => IO[E, B]`, and, indeed, `KleisliIO`
+  * extends this function type, and can be used in the same way.
+  *
+  * The main advantage to using `KleisliIO` is that it provides you a means of
+  * importing an impure function `A => B` into `KleisliIO[E, A, B]`, without
+  * actually wrapping the result of the function in an `IO` value.
+  *
+  * This allows the implementation to aggressively fuse operations on impure
+  * functions, which in turn can result in significantly higher-performance and
+  * far less heap utilization than equivalent approaches modeled with `IO`.
+  *
+  * The implementation allows you to lift functions from `A => IO[E, B]` into a
+  * `KleisliIO[E, A, B]`. Such functions cannot be optimized, but will be handled
+  * correctly and can work in conjunction with optimized (fused) `KleisliIO`.
+  *
+  * Those interested in learning more about modeling effects with `KleisliIO` are
+  * encouraged to read John Hughes paper on the subject: Generalizing Monads to
+  * Arrows (www.cse.chalmers.se/~rjmh/Papers/arrows.pdf). The implementation in
+  * this file contains many of the same combinators as Hughes implementation.
+  *
+  * A word of warning: while even very complex code can be expressed in
+  * `KleisliIO`, there is a point of diminishing return. If you find yourself
+  * using deeply nested tuples to propagate information forward, it may be no
+  * faster than using `IO`.
+  *
+  * Given the following two `KleisliIO`:
+  *
+  * {{{
+  * val readLine = KleisliIO.impureVoid((_ : Unit) => scala.Console.readLine())
+  * val printLine = KleisliIO.impureVoid((line: String) => println(line))
+  * }}}
+  *
+  * Then the following two programs are equivalent:
+  *
+  * {{{
+  * // Program 1
+  * val program1: IO[Nothing, Unit] =
+  *   for {
+  *     name <- getStrLn
+  *     _    <- putStrLn("Hello, " + name)
+  *   } yield ())
+  *
+  * // Program 2
+  * val program2: IO[Nothing, Unit] = (readLine >>> KleisliIO.lift("Hello, " + _) >>> printLine)(())
+  * }}}
+  *
+  * Similarly, the following two programs are equivalent:
+  *
+  * {{{
+  * // Program 1
+  * val program1: IO[Nothing, Unit] =
+  *   for {
+  *     line1 <- getStrLn
+  *     line2 <- getStrLn
+  *     _     <- putStrLn("You wrote: " + line1 + ", " + line2)
+  *   } yield ())
+  *
+  * // Program 2
+  * val program2: IO[Nothing, Unit] =
+  *   (readLine.zipWith(readLine)("You wrote: " + _ + ", " + _) >>> printLine)(())
+  * }}}
+  *
+  * In both of these examples, the `KleisliIO` program is faster because it is
+  * able to perform fusion of effectful functions.
+  */
+sealed trait KleisliIO[+E, -A, +B] { self =>
+
+  /**
+    * Applies the effectful function with the specified value, returning the
+    * output in `IO`.
+    */
+  val run: A => IO[E, B]
+
+  /**
+    * Maps the output of this effectful function by the specified function.
+    */
+  final def map[C](f: B => C): KleisliIO[E, A, C] = self >>> KleisliIO.lift(f)
+
+  /**
+    * Binds on the output of this effectful function.
+    */
+  final def flatMap[E1 >: E, A1 <: A, C](
+      f: B => KleisliIO[E1, A1, C]): KleisliIO[E1, A1, C] =
+    KleisliIO.flatMap(self, f)
+
+  /**
+    * Composes two effectful functions.
+    */
+  final def compose[E1 >: E, A0](
+      that: KleisliIO[E1, A0, A]): KleisliIO[E1, A0, B] =
+    KleisliIO.compose(self, that)
+
+  /**
+    * "Backwards" composition of effectful functions.
+    */
+  final def andThen[E1 >: E, C](
+      that: KleisliIO[E1, B, C]): KleisliIO[E1, A, C] =
+    that.compose(self)
+
+  /**
+    * A symbolic operator for `andThen`.
+    */
+  final def >>>[E1 >: E, C](that: KleisliIO[E1, B, C]): KleisliIO[E1, A, C] =
+    self.andThen(that)
+
+  /**
+    * A symbolic operator for `compose`.
+    */
+  final def <<<[E1 >: E, C](that: KleisliIO[E1, C, A]): KleisliIO[E1, C, B] =
+    self.compose(that)
+
+  /**
+    * Zips the output of this function with the output of that function, using
+    * the specified combiner function.
+    */
+  final def zipWith[E1 >: E, A1 <: A, C, D](that: KleisliIO[E1, A1, C])(
+      f: (B, C) => D): KleisliIO[E1, A1, D] =
+    KleisliIO.zipWith(self, that)(f)
+
+  /**
+    * Returns a new effectful function that computes the value of this function,
+    * storing it into the first element of a tuple, carrying along the input on
+    * the second element of a tuple.
+    */
+  final def first[A1 <: A, B1 >: B]: KleisliIO[E, A1, (B1, A1)] =
+    self &&& KleisliIO.identity[A1]
+
+  /**
+    * Returns a new effectful function that computes the value of this function,
+    * storing it into the second element of a tuple, carrying along the input on
+    * the first element of a tuple.
+    */
+  final def second[A1 <: A, B1 >: B]: KleisliIO[E, A1, (A1, B1)] =
+    KleisliIO.identity[A1] &&& self
+
+  /**
+    * Returns a new effectful function that can either compute the value of this
+    * effectful function (if passed `Left(a)`), or can carry along any other
+    * `C` value (if passed `Right(c)`).
+    */
+  final def left[C]: KleisliIO[E, Either[A, C], Either[B, C]] =
+    KleisliIO.left(self)
+
+  /**
+    * Returns a new effectful function that can either compute the value of this
+    * effectful function (if passed `Right(a)`), or can carry along any other
+    * `C` value (if passed `Left(c)`).
+    */
+  final def right[C]: KleisliIO[E, Either[C, A], Either[C, B]] =
+    KleisliIO.right(self)
+
+  /**
+    * Returns a new effectful function that zips together the output of two
+    * effectful functions that share the same input.
+    */
+  final def &&&[E1 >: E, A1 <: A, C](
+      that: KleisliIO[E1, A1, C]): KleisliIO[E1, A1, (B, C)] =
+    KleisliIO.zipWith(self, that)((a, b) => (a, b))
+
+  /**
+    * Returns a new effectful function that will either compute the value of this
+    * effectful function (if passed `Left(a)`), or will compute the value of the
+    * specified effectful function (if passed `Right(c)`).
+    */
+  final def |||[E1 >: E, B1 >: B, C](
+      that: KleisliIO[E1, C, B1]): KleisliIO[E1, Either[A, C], B1] =
+    KleisliIO.join(self, that)
+
+  /**
+    * Maps the output of this effectful function to the specified constant.
+    */
+  final def const[C](c: => C): KleisliIO[E, A, C] =
+    self >>> KleisliIO.lift[B, C](_ => c)
+
+  /**
+    * Maps the output of this effectful function to `Unit`.
+    */
+  final def toUnit: KleisliIO[E, A, Unit] = const(())
+
+  /**
+    * Returns a new effectful function that merely applies this one for its
+    * effect, returning the input unmodified.
+    */
+  final def asEffect[A1 <: A]: KleisliIO[E, A1, A1] =
+    self.first >>> KleisliIO._2
+}
+
+object KleisliIO {
+  private class KleisliIOError[E](error: E) extends Throwable {
+    final def unsafeCoerce[E2] = error.asInstanceOf[E2]
+  }
+
+  private[kleisliio] final class Pure[E, A, B](val run: A => IO[E, B])
+      extends KleisliIO[E, A, B] {}
+  private[kleisliio] final class Impure[E, A, B](val apply0: A => B)
+      extends KleisliIO[E, A, B] {
+    val run: A => IO[E, B] = a =>
+      IO.suspend {
+        try IO.now[B](apply0(a))
+        catch {
+          case e: KleisliIOError[_] => IO.fail[E](e.unsafeCoerce[E])
+        }
+    }
+  }
+
+  /**
+    * Lifts a value into the monad formed by `KleisliIO`.
+    */
+  final def point[B](b: => B): KleisliIO[Nothing, Any, B] = lift((_: Any) => b)
+
+  /**
+    * Returns a `KleisliIO` representing a failure with the specified `E`.
+    */
+  final def fail[E](e: E): KleisliIO[E, Any, Nothing] =
+    new Impure(_ => throw new KleisliIOError[E](e))
+
+  /**
+    * Returns the identity effectful function, which performs no effects and
+    * merely returns its input unmodified.
+    */
+  final def identity[A]: KleisliIO[Nothing, A, A] = lift(a => a)
+
+  /**
+    * Lifts a pure `A => IO[E, B]` into `KleisliIO`.
+    */
+  final def pure[E, A, B](f: A => IO[E, B]): KleisliIO[E, A, B] = new Pure(f)
+
+  /**
+    * Lifts a pure `A => B` into `KleisliIO`.
+    */
+  final def lift[A, B](f: A => B): KleisliIO[Nothing, A, B] = new Impure(f)
+
+  /**
+    * Returns an effectful function that merely swaps the elements in a `Tuple2`.
+    */
+  final def swap[E, A, B]: KleisliIO[E, (A, B), (B, A)] =
+    KleisliIO.lift[(A, B), (B, A)](_.swap)
+
+  /**
+    * Lifts an impure function into `KleisliIO`, converting throwables into the
+    * specified error type `E`.
+    */
+  final def impure[E, A, B](catcher: PartialFunction[Throwable, E])(
+      f: A => B): KleisliIO[E, A, B] =
+    new Impure(
+      (a: A) =>
+        try f(a)
+        catch {
+          case t: Throwable if catcher.isDefinedAt(t) =>
+            throw new KleisliIOError(catcher(t))
+      }
+    )
+
+  /**
+    * Lifts an impure function into `KleisliIO`, assuming any throwables are
+    * non-recoverable and do not need to be converted into errors.
+    */
+  final def impureVoid[A, B](f: A => B): KleisliIO[Nothing, A, B] =
+    new Impure(f)
+
+  /**
+    * Returns a new effectful function that passes an `A` to the condition, and
+    * if the condition returns true, returns `Left(a)`, but if the condition
+    * returns false, returns `Right(a)`.
+    */
+  final def test[E, A](
+      k: KleisliIO[E, A, Boolean]): KleisliIO[E, A, Either[A, A]] =
+    (k &&& KleisliIO.identity[A]) >>>
+      KleisliIO.lift((t: (Boolean, A)) => if (t._1) Left(t._2) else Right(t._2))
+
+  /**
+    * Returns a new effectful function that passes an `A` to the condition, and
+    * if the condition returns true, passes the `A` to the `then0` function,
+    * but if the condition returns false, passes the `A` to the `else0` function.
+    */
+  final def ifThenElse[E, A, B](
+      cond: KleisliIO[E, A, Boolean]
+  )(then0: KleisliIO[E, A, B])(else0: KleisliIO[E, A, B]): KleisliIO[E, A, B] =
+    (cond, then0, else0) match {
+      case (cond: Impure[_, _, _],
+            then0: Impure[_, _, _],
+            else0: Impure[_, _, _]) =>
+        new Impure[E, A, B](a =>
+          if (cond.apply0(a)) then0.apply0(a) else else0.apply0(a))
+      case _ => test[E, A](cond) >>> (then0 ||| else0)
+    }
+
+  /**
+    * Returns a new effectful function that passes an `A` to the condition, and
+    * if the condition returns true, passes the `A` to the `then0` function, but
+    * otherwise returns the original `A` unmodified.
+    */
+  final def ifThen[E, A](cond: KleisliIO[E, A, Boolean])(
+      then0: KleisliIO[E, A, A]): KleisliIO[E, A, A] =
+    (cond, then0) match {
+      case (cond: Impure[_, _, _], then0: Impure[_, _, _]) =>
+        new Impure[E, A, A](a => if (cond.apply0(a)) then0.apply0(a) else a)
+      case _ => ifThenElse(cond)(then0)(KleisliIO.identity[A])
+    }
+
+  /**
+    * Returns a new effectful function that passes an `A` to the condition, and
+    * if the condition returns false, passes the `A` to the `then0` function, but
+    * otherwise returns the original `A` unmodified.
+    */
+  final def ifNotThen[E, A](cond: KleisliIO[E, A, Boolean])(
+      then0: KleisliIO[E, A, A]): KleisliIO[E, A, A] =
+    (cond, then0) match {
+      case (cond: Impure[_, _, _], then0: Impure[_, _, _]) =>
+        new Impure[E, A, A](a => if (cond.apply0(a)) a else then0.apply0(a))
+      case _ => ifThenElse(cond)(KleisliIO.identity[A])(then0)
+    }
+
+  /**
+    * Returns a new effectful function that passes an `A` to the condition, and
+    * if the condition returns true, passes the `A` through the body to yield a
+    * new `A`, which repeats until the condition returns false. This is the
+    * `KleisliIO` equivalent of a `while(cond) { body }` loop.
+    */
+  final def whileDo[E, A](check: KleisliIO[E, A, Boolean])(
+      body: KleisliIO[E, A, A]): KleisliIO[E, A, A] =
+    (check, body) match {
+      case (check: Impure[_, _, _], body: Impure[_, _, _]) =>
+        new Impure[E, A, A]({ a0: A =>
+          var a = a0
+
+          val cond = check.apply0
+          val update = body.apply0
+
+          while (cond(a)) {
+            a = update(a)
+          }
+
+          a
+        })
+
+      case _ =>
+        lazy val loop: KleisliIO[E, A, A] =
+          KleisliIO.pure(
+            (a: A) =>
+              check
+                .run(a)
+                .flatMap((b: Boolean) =>
+                  if (b) body.run(a).flatMap(loop.run) else IO.now(a))
+          )
+
+        loop
+    }
+
+  /**
+    * Returns an effectful function that extracts out the first element of a
+    * tuple.
+    */
+  final def _1[E, A, B]: KleisliIO[E, (A, B), A] = lift[(A, B), A](_._1)
+
+  /**
+    * Returns an effectful function that extracts out the second element of a
+    * tuple.
+    */
+  final def _2[E, A, B]: KleisliIO[E, (A, B), B] = lift[(A, B), B](_._2)
+
+  /**
+    * See @KleisliIO.flatMap
+    */
+  final def flatMap[E, A, B, C](
+      fa: KleisliIO[E, A, B],
+      f: B => KleisliIO[E, A, C]): KleisliIO[E, A, C] =
+    new Pure((a: A) => fa.run(a).flatMap(b => f(b).run(a)))
+
+  /**
+    * See KleisliIO.compose
+    */
+  final def compose[E, A, B, C](second: KleisliIO[E, B, C],
+                                first: KleisliIO[E, A, B]): KleisliIO[E, A, C] =
+    (second, first) match {
+      case (second: Impure[_, _, _], first: Impure[_, _, _]) =>
+        new Impure(second.apply0.compose(first.apply0))
+
+      case _ =>
+        new Pure((a: A) => first.run(a).flatMap(second.run))
+    }
+
+  /**
+    * See KleisliIO.zipWith
+    */
+  final def zipWith[E, A, B, C, D](
+      l: KleisliIO[E, A, B],
+      r: KleisliIO[E, A, C])(f: (B, C) => D): KleisliIO[E, A, D] =
+    (l, r) match {
+      case (l: Impure[_, _, _], r: Impure[_, _, _]) =>
+        new Impure((a: A) => {
+          val b = l.apply0(a)
+          val c = r.apply0(a)
+
+          f(b, c)
+        })
+
+      case _ =>
+        KleisliIO.pure(
+          (a: A) =>
+            for {
+              b <- l.run(a)
+              c <- r.run(a)
+            } yield f(b, c)
+        )
+    }
+
+  /**
+    * See KleisliIO.left
+    */
+  final def left[E, A, B, C](
+      k: KleisliIO[E, A, B]): KleisliIO[E, Either[A, C], Either[B, C]] =
+    k match {
+      case k: Impure[E, A, B] =>
+        new Impure[E, Either[A, C], Either[B, C]]({
+          case Left(a)  => Left(k.apply0(a))
+          case Right(c) => Right(c)
+        })
+      case _ =>
+        KleisliIO.pure[E, Either[A, C], Either[B, C]] {
+          case Left(a)  => k.run(a).map[Either[B, C]](Left[B, C])
+          case Right(c) => IO.now[Either[B, C]](Right(c))
+        }
+    }
+
+  /**
+    * See KleisliIO.left
+    */
+  final def right[E, A, B, C](
+      k: KleisliIO[E, A, B]): KleisliIO[E, Either[C, A], Either[C, B]] =
+    k match {
+      case k: Impure[E, A, B] =>
+        new Impure[E, Either[C, A], Either[C, B]]({
+          case Left(c)  => Left(c)
+          case Right(a) => Right(k.apply0(a))
+        })
+      case _ =>
+        KleisliIO.pure[E, Either[C, A], Either[C, B]] {
+          case Left(c)  => IO.now[Either[C, B]](Left(c))
+          case Right(a) => k.run(a).map[Either[C, B]](Right[C, B])
+        }
+    }
+
+  /**
+    * See KleisliIO.|||
+    */
+  final def join[E, A, B, C](
+      l: KleisliIO[E, A, B],
+      r: KleisliIO[E, C, B]): KleisliIO[E, Either[A, C], B] =
+    (l, r) match {
+      case (l: Impure[_, _, _], r: Impure[_, _, _]) =>
+        new Impure[E, Either[A, C], B]({
+          case Left(a)  => l.apply0(a)
+          case Right(c) => r.apply0(c)
+        })
+
+      case _ =>
+        KleisliIO.pure[E, Either[A, C], B]({
+          case Left(a)  => l.run(a)
+          case Right(c) => r.run(c)
+        })
+    }
+}

--- a/core/src/test/scala/scalaz/kleisliio/AbstractRTSSpec.scala
+++ b/core/src/test/scala/scalaz/kleisliio/AbstractRTSSpec.scala
@@ -11,7 +11,9 @@ trait AbstractRTSSpec extends Specification with RTS {
       case Errors.LostRace(_)            => IO.unit
       case Errors.NothingRaced           => IO.unit
       case e =>
-        IO sync Console.err.println(
-          s"""[info] Discarding ${e.getClass.getName} ("${e.getMessage}")""")
+        IO.sync(
+          Console.err.println(
+            s"""[info] Discarding ${e.getClass.getName} ("${e.getMessage}")""")
+        )
     } *> IO.unit
 }

--- a/core/src/test/scala/scalaz/kleisliio/AbstractRTSSpec.scala
+++ b/core/src/test/scala/scalaz/kleisliio/AbstractRTSSpec.scala
@@ -1,7 +1,7 @@
 package scalaz.kleisliio
 
 import org.specs2.Specification
-import scalaz.zio.{Errors, IO, RTS}
+import scalaz.zio.{ Errors, IO, RTS }
 
 trait AbstractRTSSpec extends Specification with RTS {
   override def defaultHandler: List[Throwable] => IO[Nothing, Unit] =
@@ -12,8 +12,7 @@ trait AbstractRTSSpec extends Specification with RTS {
       case Errors.NothingRaced           => IO.unit
       case e =>
         IO.sync(
-          Console.err.println(
-            s"""[info] Discarding ${e.getClass.getName} ("${e.getMessage}")""")
+          Console.err.println(s"""[info] Discarding ${e.getClass.getName} ("${e.getMessage}")""")
         )
     } *> IO.unit
 }

--- a/core/src/test/scala/scalaz/kleisliio/AbstractRTSSpec.scala
+++ b/core/src/test/scala/scalaz/kleisliio/AbstractRTSSpec.scala
@@ -1,0 +1,17 @@
+package scalaz.kleisliio
+
+import org.specs2.Specification
+import scalaz.zio.{Errors, IO, RTS}
+
+trait AbstractRTSSpec extends Specification with RTS {
+  override def defaultHandler: List[Throwable] => IO[Nothing, Unit] =
+    IO.traverse(_) {
+      case Errors.UnhandledError(_, _)   => IO.unit
+      case Errors.TerminatedException(_) => IO.unit
+      case Errors.LostRace(_)            => IO.unit
+      case Errors.NothingRaced           => IO.unit
+      case e =>
+        IO sync Console.err.println(
+          s"""[info] Discarding ${e.getClass.getName} ("${e.getMessage}")""")
+    } *> IO.unit
+}

--- a/core/src/test/scala/scalaz/kleisliio/KleisliIOSpec.scala
+++ b/core/src/test/scala/scalaz/kleisliio/KleisliIOSpec.scala
@@ -1,0 +1,203 @@
+package scalaz.kleisliio
+
+import KleisliIO._
+import scalaz.zio.IO
+
+class KleisliIOSpec extends AbstractRTSSpec {
+  def is = "KleisliIOSpec".title ^ s2"""
+   Check if the functions in `KleisliIO` work correctly
+     `lift` lifts from A => B into effectful function $e1
+     `identity` returns the identity of the input without modification $e2
+     `>>>` is a symbolic operator of `andThen`which does a Backwards composition of effectul functions $e3
+     `<<<` is a symbolic operator of `compose` which compses two effectful functions $e4
+     `zipWith` zips the output of two effectful functions $e5
+     `&&&` zips the output of two effectful functions and returns a tuple of their result $e6
+     `|||` computes two effectful functions left and right from from an Either input $e7
+     `first` returns a tuple: the output on the first element and input on the second element $e8
+     `second` returns a tuple: the input on the first element and output on the second element $e9
+     `left` takes an Either as input and computes it if it is Left otherwise returns the same value of the input $e10
+     `right`takes an Either as input and computes it if it is Right otherwise returns the same value of the input   $e11
+     `asEffect` returns the input value $e12
+     `test` check a condition and returns an Either output: Left if the condition is true otherwise false $e13
+     `ifThenElse` check an impure condition if it is true then computes an effectful function `then0` else computes `else0` $e14a
+     `ifThenElse` check a pure condition if it is true then computes an effectful function `then0` else computes `else0` $e14b
+     `whileDo` take a condition and run the body until the condition will be  false with impure function $e15a
+     `whileDo` take a condition and run the body until the condition will be  false with pure function $e15b
+     `_1` extracts out the first element of a tupe $e16
+     `_2` extracts out the second element of a tupe $e17
+     `fail` returns a failure  $e18a
+     `impure` can translate an Exception to an error  $e18b
+    """
+
+  def e1 =
+    unsafeRun(
+      for {
+        v <- lift[Int, Int](_ + 1).run(4)
+      } yield v must_=== 5
+    )
+
+  def e2 =
+    unsafeRun(
+      for {
+        v <- identity[Int].run(1)
+      } yield v must_=== 1
+    )
+
+  def e3 =
+    unsafeRun(
+      for {
+        v <- (lift[Int, Int](_ + 1) >>> lift[Int, Int](_ * 2)).run(6)
+      } yield v must_=== 14
+    )
+
+  def e4 =
+    unsafeRun(
+      for {
+        v <- (lift[Int, Int](_ + 1) <<< lift[Int, Int](_ * 2)).run(6)
+      } yield v must_=== 13
+    )
+
+  def e5 =
+    unsafeRun(
+      for {
+        v <- point(1)
+          .zipWith[Nothing, Int, Int, Int](point(2))((a, b) => a + b)
+          .run(1)
+      } yield v must_=== 3
+    )
+
+  def e6 =
+    unsafeRun(
+      for {
+        v <- (lift[Int, Int](_ + 1) &&& lift[Int, Int](_ * 2)).run(6)
+      } yield (v._1 must_=== 7) and (v._2 must_=== 12)
+    )
+
+  def e7 =
+    unsafeRun(
+      for {
+        l <- (lift[Int, Int](_ + 1) ||| lift[Int, Int](_ * 2)).run(Left(25))
+        r <- (lift[List[Int], Int](_.sum) ||| lift[List[Int], Int](_.size))
+          .run(Right(List(1, 3, 5, 2, 8)))
+      } yield (l must_=== 26) and (r must_=== 5)
+    )
+
+  def e8 =
+    unsafeRun(
+      for {
+        v <- lift[Int, Int](_ * 2).first.run(100)
+      } yield (v._1 must_=== 200) and (v._2 must_=== 100)
+    )
+
+  def e9 =
+    unsafeRun(
+      for {
+        v <- lift[Int, Int](_ * 2).second.run(100)
+      } yield (v._1 must_=== 100) and (v._2 must_=== 200)
+    )
+  def e10 =
+    unsafeRun(
+      for {
+        v1 <- lift[Int, Int](_ * 2).left[Int].run(Left(6))
+        v2 <- point(1).left[String].run(Right("hi"))
+      } yield (v1 must beLeft(12)) and (v2 must beRight("hi"))
+    )
+
+  def e11 =
+    unsafeRun(
+      for {
+        v1 <- lift[Int, Int](_ * 2).right[String].run(Left("no value"))
+        v2 <- lift[Int, Int](_ * 2).right[Int].run(Right(7))
+      } yield (v1 must beLeft("no value")) and (v2 must beRight(14))
+    )
+
+  def e12 =
+    unsafeRun(
+      for {
+        v <- lift[Int, Int](_ * 2).asEffect.run(56)
+      } yield v must_=== 56
+    )
+
+  def e13 =
+    unsafeRun(
+      for {
+        v1 <- test(lift[Array[Int], Boolean](_.sum > 10)).run(Array(1, 2, 5))
+        v2 <- test(lift[Array[Int], Boolean](_.sum > 10)).run(Array(1, 2, 5, 6))
+      } yield
+        (v1 must beRight(Array(1, 2, 5))) and (v2 must beLeft(
+          Array(1, 2, 5, 6)))
+    )
+
+  def e14a =
+    unsafeRun(
+      for {
+        v1 <- ifThenElse(lift[Int, Boolean](_ > 0))(point("is positive"))(
+          point("is negative")
+        ).run(-1)
+        v2 <- ifThenElse(lift[Int, Boolean](_ > 0))(point("is positive"))(
+          point("is negative")
+        ).run(1)
+      } yield (v1 must_=== "is negative") and (v2 must_=== "is positive")
+    )
+
+  def e14b =
+    unsafeRun(
+      for {
+        v1 <- ifThenElse(pure[Nothing, Int, Boolean](a => IO.now(a > 0)))(
+          point("is positive"))(
+          point("is negative")
+        ).run(-1)
+        v2 <- ifThenElse(pure[Nothing, Int, Boolean](a => IO.now(a > 0)))(
+          point("is positive"))(
+          point("is negative")
+        ).run(1)
+      } yield (v1 must_=== "is negative") and (v2 must_=== "is positive")
+    )
+
+  def e15a =
+    unsafeRun(
+      for {
+        v <- whileDo[Nothing, Int](lift[Int, Boolean](_ < 10))(
+          lift[Int, Int](_ + 1)).run(1)
+      } yield v must_=== 10
+    )
+
+  def e15b =
+    unsafeRun(
+      for {
+        v <- whileDo[Nothing, Int](
+          pure[Nothing, Int, Boolean](a => IO.now[Boolean](a < 10)))(
+          pure[Nothing, Int, Int](a => IO.sync[Int](a + 1))
+        ).run(1)
+      } yield v must_=== 10
+    )
+
+  def e16 =
+    unsafeRun(
+      for {
+        v <- _1[Nothing, Int, String].run((1, "hi"))
+      } yield v must_=== 1
+    )
+
+  def e17 =
+    unsafeRun(
+      for {
+        v <- _2[Nothing, Int, String].run((2, "hola"))
+      } yield v must_=== "hola"
+    )
+
+  def e18a =
+    unsafeRun(
+      for {
+        a <- fail[String]("error").run(1).attempt
+      } yield a must beLeft("error")
+    )
+
+  def e18b =
+    unsafeRun(
+      for {
+        a <- impure[String, Int, Int] { case _: Throwable => "error" }(_ =>
+          throw new Exception).run(9).attempt
+      } yield a must beLeft("error")
+    )
+}

--- a/core/src/test/scala/scalaz/kleisliio/KleisliIOSpec.scala
+++ b/core/src/test/scala/scalaz/kleisliio/KleisliIOSpec.scala
@@ -61,8 +61,8 @@ class KleisliIOSpec extends AbstractRTSSpec {
     unsafeRun(
       for {
         v <- point(1)
-          .zipWith[Nothing, Int, Int, Int](point(2))((a, b) => a + b)
-          .run(1)
+              .zipWith[Nothing, Int, Int, Int](point(2))((a, b) => a + b)
+              .run(1)
       } yield v must_=== 3
     )
 
@@ -70,7 +70,7 @@ class KleisliIOSpec extends AbstractRTSSpec {
     unsafeRun(
       for {
         v <- (lift[Int, Int](_ + 1) &&& lift[Int, Int](_ * 2)).run(6)
-      } yield (v._1 must_=== 7) and (v._2 must_=== 12)
+      } yield (v._1 must_=== 7).and(v._2 must_=== 12)
     )
 
   def e7 =
@@ -78,29 +78,30 @@ class KleisliIOSpec extends AbstractRTSSpec {
       for {
         l <- (lift[Int, Int](_ + 1) ||| lift[Int, Int](_ * 2)).run(Left(25))
         r <- (lift[List[Int], Int](_.sum) ||| lift[List[Int], Int](_.size))
-          .run(Right(List(1, 3, 5, 2, 8)))
-      } yield (l must_=== 26) and (r must_=== 5)
+              .run(Right(List(1, 3, 5, 2, 8)))
+      } yield (l must_=== 26).and(r must_=== 5)
     )
 
   def e8 =
     unsafeRun(
       for {
         v <- lift[Int, Int](_ * 2).first.run(100)
-      } yield (v._1 must_=== 200) and (v._2 must_=== 100)
+      } yield (v._1 must_=== 200).and(v._2 must_=== 100)
     )
 
   def e9 =
     unsafeRun(
       for {
         v <- lift[Int, Int](_ * 2).second.run(100)
-      } yield (v._1 must_=== 100) and (v._2 must_=== 200)
+      } yield (v._1 must_=== 100).and(v._2 must_=== 200)
     )
+
   def e10 =
     unsafeRun(
       for {
         v1 <- lift[Int, Int](_ * 2).left[Int].run(Left(6))
         v2 <- point(1).left[String].run(Right("hi"))
-      } yield (v1 must beLeft(12)) and (v2 must beRight("hi"))
+      } yield (v1 must beLeft(12)).and(v2 must beRight("hi"))
     )
 
   def e11 =
@@ -108,7 +109,7 @@ class KleisliIOSpec extends AbstractRTSSpec {
       for {
         v1 <- lift[Int, Int](_ * 2).right[String].run(Left("no value"))
         v2 <- lift[Int, Int](_ * 2).right[Int].run(Right(7))
-      } yield (v1 must beLeft("no value")) and (v2 must beRight(14))
+      } yield (v1 must beLeft("no value")).and(v2 must beRight(14))
     )
 
   def e12 =
@@ -123,52 +124,46 @@ class KleisliIOSpec extends AbstractRTSSpec {
       for {
         v1 <- test(lift[Array[Int], Boolean](_.sum > 10)).run(Array(1, 2, 5))
         v2 <- test(lift[Array[Int], Boolean](_.sum > 10)).run(Array(1, 2, 5, 6))
-      } yield
-        (v1 must beRight(Array(1, 2, 5))) and (v2 must beLeft(
-          Array(1, 2, 5, 6)))
+      } yield (v1 must beRight(Array(1, 2, 5))).and(v2 must beLeft(Array(1, 2, 5, 6)))
     )
 
   def e14a =
     unsafeRun(
       for {
         v1 <- ifThenElse(lift[Int, Boolean](_ > 0))(point("is positive"))(
-          point("is negative")
-        ).run(-1)
+               point("is negative")
+             ).run(-1)
         v2 <- ifThenElse(lift[Int, Boolean](_ > 0))(point("is positive"))(
-          point("is negative")
-        ).run(1)
-      } yield (v1 must_=== "is negative") and (v2 must_=== "is positive")
+               point("is negative")
+             ).run(1)
+      } yield (v1 must_=== "is negative").and(v2 must_=== "is positive")
     )
 
   def e14b =
     unsafeRun(
       for {
-        v1 <- ifThenElse(pure[Nothing, Int, Boolean](a => IO.now(a > 0)))(
-          point("is positive"))(
-          point("is negative")
-        ).run(-1)
-        v2 <- ifThenElse(pure[Nothing, Int, Boolean](a => IO.now(a > 0)))(
-          point("is positive"))(
-          point("is negative")
-        ).run(1)
-      } yield (v1 must_=== "is negative") and (v2 must_=== "is positive")
+        v1 <- ifThenElse(pure[Nothing, Int, Boolean](a => IO.now(a > 0)))(point("is positive"))(
+               point("is negative")
+             ).run(-1)
+        v2 <- ifThenElse(pure[Nothing, Int, Boolean](a => IO.now(a > 0)))(point("is positive"))(
+               point("is negative")
+             ).run(1)
+      } yield (v1 must_=== "is negative").and(v2 must_=== "is positive")
     )
 
   def e15a =
     unsafeRun(
       for {
-        v <- whileDo[Nothing, Int](lift[Int, Boolean](_ < 10))(
-          lift[Int, Int](_ + 1)).run(1)
+        v <- whileDo[Nothing, Int](lift[Int, Boolean](_ < 10))(lift[Int, Int](_ + 1)).run(1)
       } yield v must_=== 10
     )
 
   def e15b =
     unsafeRun(
       for {
-        v <- whileDo[Nothing, Int](
-          pure[Nothing, Int, Boolean](a => IO.now[Boolean](a < 10)))(
-          pure[Nothing, Int, Int](a => IO.sync[Int](a + 1))
-        ).run(1)
+        v <- whileDo[Nothing, Int](pure[Nothing, Int, Boolean](a => IO.now[Boolean](a < 10)))(
+              pure[Nothing, Int, Int](a => IO.sync[Int](a + 1))
+            ).run(1)
       } yield v must_=== 10
     )
 
@@ -196,8 +191,9 @@ class KleisliIOSpec extends AbstractRTSSpec {
   def e18b =
     unsafeRun(
       for {
-        a <- impure[String, Int, Int] { case _: Throwable => "error" }(_ =>
-          throw new Exception).run(9).attempt
+        a <- impure[String, Int, Int] { case _: Throwable => "error" }(_ => throw new Exception)
+              .run(9)
+              .attempt
       } yield a must beLeft("error")
     )
 }


### PR DESCRIPTION
This PR contains all the necessary *KleisliIO* related code contained in `ZIO` project.

`build.sbt` has been configured as multi-project since benchmarks are needed

so the two main projects inside *root* are `benchmarks` and `core`

from the `sbt` command line you can run:
1. `project benchmarks`
2. `jmh:run -i 20 -wi 20 -f1 -t1 .*.`, in order to run the benchmarks
* *jmh pluging documentation can be found [here](https://github.com/ktoso/sbt-jmh)*

or

1. `project core`
2. `test`, in order to execute the tests

Fixes #2 